### PR TITLE
fix pristine command

### DIFF
--- a/src/configProvider.ts
+++ b/src/configProvider.ts
@@ -32,14 +32,17 @@ export default () => {
   if (!instance) {
     const envFilePath = getConfig(`MB_ENV_FILE`);
 
-    const overrideEnvFilePath = getConfig(`MB_ENV_FILE_OVR`);
+    let overrideEnvFilePath;
+    try {
+      overrideEnvFilePath = getConfig(`MB_ENV_FILE_OVR`);
+    } catch {}
 
     config({
       path: path.join(__dirname, `..`, envFilePath),
     });
 
     // checks to see if the dev-overrides.env file is present in root directory
-    if (fs.existsSync(path.join(__dirname, `..`, overrideEnvFilePath))) {
+    if (overrideEnvFilePath && fs.existsSync(path.join(__dirname, `..`, overrideEnvFilePath))) {
       // override
       const envConfig = parse(fs.readFileSync(path.join(__dirname, `..`, overrideEnvFilePath)));
 


### PR DESCRIPTION
`yarn pristine` was giving me the following error:

<img width="800" alt="Screen Shot 2021-07-04 at 4 34 49 PM" src="https://user-images.githubusercontent.com/21327242/124398869-05a1a300-dce6-11eb-8adf-c6112e6697c2.png">

This is due to the fact that `getConfig` throws an error when it can't find the variable. Yet, we're using `getConfig` to test if a variable exists, for some reason.

Fixed it by `try`/`catch`ing it and swallowing the error.